### PR TITLE
Drop PHP7 support and refactor migration file

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest ]
-        laravel: [ 11.*, 10.*, 9.*, 8.*, 7.*, 6.*, 5.* ]
+        laravel: [ 11.*, 10.*, 9.*, 8.* ]
         dependency-version: [ prefer-stable ]
         include:
           - laravel: 11.*
@@ -31,18 +31,6 @@ jobs:
           - laravel: 8.*
             testbench: 6.*
             php: 8.1
-
-          - laravel: 7.*
-            testbench: 5.*
-            php: 8.0
-
-          - laravel: 6.*
-            testbench: 4.*
-            php: 8.0
-
-          - laravel: 5.*
-            testbench: 3.*
-            php: 7.4
 
     name: ${{ matrix.os }} - P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /vendor
+/*.cache
 composer.phar
 composer.lock
 Thumbs.db

--- a/README.md
+++ b/README.md
@@ -31,14 +31,21 @@ An easy, native role / permission management system for Laravel.
 
 To get started, install Authorization via the Composer package manager:
 
-    composer require directorytree/authorization
+```bash
+composer require directorytree/authorization
+```
 
-The Authorization service provider registers its own database migration directory
-with the framework, so you should migrate your database after installing the
-package. The Authorization migrations will create the tables your
-application needs to store roles and permissions:
+You should publish the migration file as the package needs to store roles and permissions:
 
-    php artisan migrate
+```bash
+php artisan vendor:publish --tag=authorization-migrations"
+```
+
+Run migrations
+
+```bash
+php artisan migrate
+```
 
 Now insert the `DirectoryTree\Authorization\Traits\Authorizable` onto your `App\Models\User` model:
 
@@ -59,27 +66,6 @@ class User extends Authenticatable
 ```
 
 You can now perform user authorization.
-
-### Migration Customization
-
-If you would not like to use Authorization's default migrations, you should call the
-`Authorization::ignoreMigrations` method in the `register` method of your
-`AppServiceProvider`. You may export the default migrations using
-`php artisan vendor:publish --tag=authorization-migrations`.
-
-```php
-use DirectoryTree\Authorization\Authorization;
-
-/**
- * Register any application services.
- *
- * @return void
- */
-public function register()
-{
-    Authorization::ignoreMigrations();
-}
-```
 
 ### Model Customization
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ An easy, native role / permission management system for Laravel.
 ## Index
 
 -   [Installation](#installation)
-    -   [Migration Customization](#migration-customization)
     -   [Model Customization](#model-customization)
 -   [Usage](#usage)
 -   [Checking Permissions & Roles](#checking-permissions--roles)
@@ -38,7 +37,7 @@ composer require directorytree/authorization
 You should publish the migration file as the package needs to store roles and permissions:
 
 ```bash
-php artisan vendor:publish --tag=authorization-migrations"
+php artisan vendor:publish --tag="authorization-migrations"
 ```
 
 Run migrations

--- a/composer.json
+++ b/composer.json
@@ -11,12 +11,12 @@
     "license": "MIT",
     "type": "project",
     "require": {
-        "php": ">=7.4",
-        "illuminate/database": "^5.5|^6.20|^7.0|^8.0|^9.0|^10.0|^11.0"
+        "php": "^8.0",
+        "illuminate/database": "^8.0|^9.0|^10.0|^11.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^3.7|^4.0|^5.0|^6.0|^7.0|^8.0|^9.0",
-        "phpunit/phpunit": "^7.0|^8.0|^9.0|^10.0"
+        "orchestra/testbench": "^6.0|^7.0|^8.0|^9.0",
+        "phpunit/phpunit": "^9.0|^10.0"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,
@@ -36,5 +36,11 @@
                 "DirectoryTree\\Authorization\\AuthorizationServiceProvider"
             ]
         }
+    },
+    "config": {
+        "sort-packages": true
+    },
+    "scripts": {
+        "test": "vendor/bin/phpunit"
     }
 }

--- a/database/migrations/create_authorization_tables.php
+++ b/database/migrations/create_authorization_tables.php
@@ -4,14 +4,12 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class CreateAuthorizationTables extends Migration
+return new class extends Migration
 {
     /**
      * Run the migrations.
-     *
-     * @return void
      */
-    public function up()
+    public function up(): void
     {
         Schema::create('roles', function (Blueprint $table) {
             $table->increments('id');
@@ -51,10 +49,8 @@ class CreateAuthorizationTables extends Migration
 
     /**
      * Reverse the migrations.
-     *
-     * @return void
      */
-    public function down()
+    public function down(): void
     {
         Schema::dropIfExists('role_user');
         Schema::dropIfExists('permission_role');
@@ -62,4 +58,4 @@ class CreateAuthorizationTables extends Migration
         Schema::dropIfExists('permissions');
         Schema::dropIfExists('roles');
     }
-}
+};

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,24 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
-         bootstrap="vendor/autoload.php"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false"
->
-    <testsuites>
-        <testsuite name="Package Test Suite">
-            <directory suffix="Test.php">./tests/</directory>
-        </testsuite>
-    </testsuites>
-    <php>
-        <env name="APP_ENV" value="testing"/>
-        <env name="CACHE_DRIVER" value="array"/>
-        <env name="SESSION_DRIVER" value="array"/>
-        <env name="DB_CONNECTION" value="sqlite"/>
-        <env name="DB_DATABASE" value=":memory:"/>
-    </php>
+<phpunit 
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  backupGlobals="false" 
+  bootstrap="vendor/autoload.php"
+  colors="true"
+  processIsolation="false"
+  stopOnFailure="false"
+  xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+  cacheDirectory=".phpunit.cache"
+  backupStaticProperties="false"
+  >
+  <testsuites>
+    <testsuite name="Package Test Suite">
+      <directory suffix="Test.php">./tests/</directory>
+    </testsuite>
+  </testsuites>
+  <php>
+    <env name="APP_ENV" value="testing"/>
+    <env name="CACHE_DRIVER" value="array"/>
+    <env name="SESSION_DRIVER" value="array"/>
+    <env name="DB_CONNECTION" value="sqlite"/>
+    <env name="DB_DATABASE" value=":memory:"/>
+  </php>
 </phpunit>

--- a/src/Authorization.php
+++ b/src/Authorization.php
@@ -7,13 +7,6 @@ use DateTimeInterface;
 class Authorization
 {
     /**
-     * Indicates if Authorization migrations will be run.
-     *
-     * @var bool
-     */
-    public static $runsMigrations = true;
-
-    /**
      * Indicates if Authorization will register permissions into the gate.
      *
      * @var bool
@@ -208,18 +201,6 @@ class Authorization
     public static function disablePermissionCache()
     {
         static::$cachesPermissions = false;
-
-        return new static;
-    }
-
-    /**
-     * Configure Authorization to not register its migrations.
-     *
-     * @return static
-     */
-    public static function ignoreMigrations()
-    {
-        static::$runsMigrations = false;
 
         return new static;
     }

--- a/src/AuthorizationServiceProvider.php
+++ b/src/AuthorizationServiceProvider.php
@@ -14,28 +14,14 @@ class AuthorizationServiceProvider extends ServiceProvider
     public function boot()
     {
         if ($this->app->runningInConsole()) {
-            $this->registerMigrations();
-
             $this->publishes([
-                __DIR__.'/../database/migrations' => database_path('migrations'),
+                __DIR__.'/../database/migrations/create_authorization_tables.php' => database_path('migrations/'.date('Y_m_d_His', time()).'_create_authorization_tables.php'),
             ], 'authorization-migrations');
         }
 
         // Register the permissions.
         if (Authorization::$registersInGate) {
             app(PermissionRegistrar::class)->register();
-        }
-    }
-
-    /**
-     * Register Authorization migration files.
-     *
-     * @return void
-     */
-    protected function registerMigrations()
-    {
-        if (Authorization::$runsMigrations) {
-            $this->loadMigrationsFrom(__DIR__.'/../database/migrations');
         }
     }
 }

--- a/tests/Stubs/User.php
+++ b/tests/Stubs/User.php
@@ -9,5 +9,7 @@ class User extends BaseUser
 {
     use Authorizable;
 
-    protected $fillable = ['name'];
+    protected $fillable = [
+        'name', 'email', 'password',
+    ];
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,27 +2,33 @@
 
 namespace DirectoryTree\Authorization\Tests;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Schema;
+use Illuminate\Foundation\Testing\WithFaker;
 use DirectoryTree\Authorization\Authorization;
-use DirectoryTree\Authorization\AuthorizationServiceProvider;
 use DirectoryTree\Authorization\Tests\Stubs\User;
 use Orchestra\Testbench\TestCase as BaseTestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use DirectoryTree\Authorization\AuthorizationServiceProvider;
 
-class TestCase extends BaseTestCase
+abstract class TestCase extends BaseTestCase
 {
     use RefreshDatabase;
+    use WithFaker;
 
     public function setUp(): void
     {
         parent::setUp();
+    }
 
-        // Create the users table for testing.
-        Schema::create('users', function ($table) {
-            $table->increments('id');
-            $table->string('name');
-            $table->timestamps();
-        });
+    /**
+     * {@inheritdoc}
+     */
+    protected function defineDatabaseMigrations()
+    {
+        $this->loadMigrationsFrom(base_path('migrations'));
+        $this->loadMigrationsFrom(__DIR__.'/../database/migrations');
     }
 
     /**
@@ -44,6 +50,8 @@ class TestCase extends BaseTestCase
      */
     protected function createUser($attributes = [])
     {
+        $attributes['email'] = $this->faker->unique()->safeEmail;
+        $attributes['password'] = Hash::make(Str::random(10));
         return User::create($attributes);
     }
 


### PR DESCRIPTION
Changes
- Drop PHP7 support to enforce PHP8 upgrade as PHP7 has reached end-of-life support including security fixes.
- Update migration file to publish migration file with current timestamp instead of the hard-coded timestamp. This is better for auditing to know when the file was generated.
- Update the installation step to include the publish step for migration files for customization or applying default migration. this allows as well migration files to be version-controlled on the project.
- Drop support for Laravel 5,6,7 as those have reached end-of-life support.


PS. This should probably be a major release to start migrating coding standards to PHP8.