### PR TITLE
Do not run script in console

### DIFF
--- a/src/PermissionRegistrar.php
+++ b/src/PermissionRegistrar.php
@@ -57,7 +57,7 @@ class PermissionRegistrar
     public function getPermissions()
     {
         try {
-            if (Authorization::$cachesPermissions) {
+            if (Authorization::$cachesPermissions && !app()->runningInConsole()) {
                 return $this->cache->remember(Authorization::cacheKey(), Authorization::cacheExpiresIn(), function () {
                     return Authorization::permission()->get();
                 });


### PR DESCRIPTION
This was preventing artisan to run if the driver is not available, e.g. with octane. Octane needs artisan to start, so this solves a dead lock. 